### PR TITLE
added #pragma semicolon support

### DIFF
--- a/amxmodx/scripting/include/orpheu.inc
+++ b/amxmodx/scripting/include/orpheu.inc
@@ -15,7 +15,7 @@
  *
  * @return 					A handler to the function
  */
-native OrpheuFunction:OrpheuGetFunction(const libFunctionName[],const className[]="")
+native OrpheuFunction:OrpheuGetFunction(const libFunctionName[],const className[]="");
 
 /**
  * Hooks a function
@@ -26,14 +26,14 @@ native OrpheuFunction:OrpheuGetFunction(const libFunctionName[],const className[
  *
  * @return 					A handler to the hook
  */
-native OrpheuHook:OrpheuRegisterHook(OrpheuFunction:function,const hookFunctionName[],OrpheuHookPhase:phase = OrpheuHookPre)
+native OrpheuHook:OrpheuRegisterHook(OrpheuFunction:function,const hookFunctionName[],OrpheuHookPhase:phase = OrpheuHookPre);
 
 /**
  * Unregisters a hook (stops it)
  *
  * @param hook			A handler to the hook
  */
-native OrpheuUnregisterHook(OrpheuHook:hook)
+native OrpheuUnregisterHook(OrpheuHook:hook);
 
 /**
  * Calls a function without triggering its hooks
@@ -41,7 +41,7 @@ native OrpheuUnregisterHook(OrpheuHook:hook)
  * @param function		A handler to the function
  * @param any			The arguments of the function
  */
-native OrpheuCall(OrpheuFunction:function,any:...)
+native OrpheuCall(OrpheuFunction:function,any:...);
 
 /**
  * Calls a function and triggers its hooks
@@ -49,7 +49,7 @@ native OrpheuCall(OrpheuFunction:function,any:...)
  * @param function		A handler to the function
  * @param any			The arguments of the function
  */
-native OrpheuCallSuper(OrpheuFunction:function,any:...)
+native OrpheuCallSuper(OrpheuFunction:function,any:...);
 
 /**
  * Gets the return value of a function (To be used in hooks Post)
@@ -57,14 +57,14 @@ native OrpheuCallSuper(OrpheuFunction:function,any:...)
  * @param any			In case the value is multi cell (string or vector), an holder to receive them by ref
  * @return				In case the value is uni cell, the value itself
  */
-native any:OrpheuGetReturn(any:...)
+native any:OrpheuGetReturn(any:...);
 
 /**
  * Sets the return value of a function
  *
  * @param any			Depending on the type of the return of the function, a value to be used as the return as the original hooked function
  */
-native OrpheuSetReturn(any:...)
+native OrpheuSetReturn(any:...);
 
 /**
  * Sets the value of an argument
@@ -72,7 +72,7 @@ native OrpheuSetReturn(any:...)
  * @param num 			The number of the argument. The first argument would be the number "1"
  * @param any			Depending on the type of the argument, a value to be replace it to change the behaviour of the hooked function
  */
-native OrpheuSetParam(num,any:...)
+native OrpheuSetParam(num,any:...);
 
 /**
  * Creates a struct
@@ -81,7 +81,7 @@ native OrpheuSetParam(num,any:...)
  * 
  * @return				A handler to the struct
  */
-native OrpheuStruct:OrpheuCreateStruct(OrpheuStructType:structType)
+native OrpheuStruct:OrpheuCreateStruct(OrpheuStructType:structType);
 
 /**
  * Retrieves the value of a member of a struct given the argument number the struct is and the member name
@@ -92,7 +92,7 @@ native OrpheuStruct:OrpheuCreateStruct(OrpheuStructType:structType)
  * 
  * @return				In case the value is uni cell, the value itself
  */
-native OrpheuGetParamStructMember(num,const memberName[],any:...)
+native OrpheuGetParamStructMember(num,const memberName[],any:...);
 
 /**
  * Sets the value of member of a struct given the argument number the struct is and the member name
@@ -101,7 +101,7 @@ native OrpheuGetParamStructMember(num,const memberName[],any:...)
  * @param memberName 	The name of the member of the struct we want to deal with
  * @param any 			The new value
  */
-native OrpheuSetParamStructMember(num,const memberName[],any:...)
+native OrpheuSetParamStructMember(num,const memberName[],any:...);
 
 /**
  * Gets a struct handler for a struct received as an argument 
@@ -111,7 +111,7 @@ native OrpheuSetParamStructMember(num,const memberName[],any:...)
  * 
  * @return				A handler to the struct
  */
-native OrpheuStruct:OrpheuGetStructFromParam(num)
+native OrpheuStruct:OrpheuGetStructFromParam(num);
 
 /**
  * Creates a struct equal to one received as an argument
@@ -120,7 +120,7 @@ native OrpheuStruct:OrpheuGetStructFromParam(num)
  * 
  * @return				A handler to the struct
  */
-native OrpheuStruct:OrpheuCloneStructFromParam(num)
+native OrpheuStruct:OrpheuCloneStructFromParam(num);
 
 /**
  * Sets the value of a member of a struct given a struct handler and the member name
@@ -129,7 +129,7 @@ native OrpheuStruct:OrpheuCloneStructFromParam(num)
  * @param memberName 	The name of the member of the struct we want to deal with
  * @param any 			The new value
  */
-native OrpheuSetStructMember(OrpheuStruct:struct,const memberName[],any:...)
+native OrpheuSetStructMember(OrpheuStruct:struct,const memberName[],any:...);
 
 /**
  * Retrieves the value of a member of a struct given a struct handler and the member name
@@ -140,7 +140,7 @@ native OrpheuSetStructMember(OrpheuStruct:struct,const memberName[],any:...)
  * 
  * @return				In case the value is uni cell, the value itself
  */
-native OrpheuGetStructMember(OrpheuStruct:struct,const memberName[],any:...)
+native OrpheuGetStructMember(OrpheuStruct:struct,const memberName[],any:...);
 
 /**
  * Retrieves a handler to a struct that hold the addresses of the engine functions
@@ -149,7 +149,7 @@ native OrpheuGetStructMember(OrpheuStruct:struct,const memberName[],any:...)
  
  * @return				A handler to a struct that holds the engine functions
  */
-native OrpheuStruct:OrpheuGetEngineFunctionsStruct()
+native OrpheuStruct:OrpheuGetEngineFunctionsStruct();
 
 /**
  * Retrieves a handler to a struct that hold the addresses of the dll functions
@@ -158,7 +158,7 @@ native OrpheuStruct:OrpheuGetEngineFunctionsStruct()
  
  * @return				A handler to a struct that holds the dll functions
  */
-native OrpheuStruct:OrpheuGetDLLFunctionsStruct()
+native OrpheuStruct:OrpheuGetDLLFunctionsStruct();
 
 /**
  * Retrieves a handler to a function given a classname, the function name and the classname
@@ -172,7 +172,7 @@ native OrpheuStruct:OrpheuGetDLLFunctionsStruct()
  * @param libClassName	 	The library function name as it is in the file created to define the function
  * @return					A handler to the function
  */
-native OrpheuFunction:OrpheuGetFunctionFromClass(const entityClassName[],const libFunctionName[],const libClassName[])
+native OrpheuFunction:OrpheuGetFunctionFromClass(const entityClassName[],const libFunctionName[],const libClassName[]);
 
 /**
  * Retrieves a handler to a function given the ID of an entity, the function name and the classname
@@ -186,7 +186,7 @@ native OrpheuFunction:OrpheuGetFunctionFromClass(const entityClassName[],const l
  * @param libClassName	 	The library function name as it is in the file created to define the function
  * @return					A handler to the function
  */
-native OrpheuFunction:OrpheuGetFunctionFromEntity(id,const libFunctionName[],const libClassName[])
+native OrpheuFunction:OrpheuGetFunctionFromEntity(id,const libFunctionName[],const libClassName[]);
 
 /**
  * Retrieves a handler to a function given an object, the function name and the classname
@@ -200,7 +200,7 @@ native OrpheuFunction:OrpheuGetFunctionFromEntity(id,const libFunctionName[],con
  * @param libClassName	 	The library function name as it is in the file created to define the function
  * @return					A handler to the function
  */
-native OrpheuFunction:OrpheuGetFunctionFromObject(object,const libFunctionName[],const libClassName[])
+native OrpheuFunction:OrpheuGetFunctionFromObject(object,const libFunctionName[],const libClassName[]);
 
 /**
  * Retrieves a handler to a function given the id of a monster of monstermod, the function name and the classname
@@ -217,4 +217,4 @@ native OrpheuFunction:OrpheuGetFunctionFromObject(object,const libFunctionName[]
  * @param libClassName	 	The library function name as it is in the file created to define the function
  * @return					A handler to the function
  */
-native OrpheuFunction:OrpheuGetFunctionFromMonster(id, const libFunctionName[], const libClassName[])
+native OrpheuFunction:OrpheuGetFunctionFromMonster(id, const libFunctionName[], const libClassName[]);

--- a/amxmodx/scripting/include/orpheu.inc
+++ b/amxmodx/scripting/include/orpheu.inc
@@ -6,6 +6,7 @@
 
 #include <orpheu_const>
 
+
 /**
  * Retrieves a function based on a function name
  * The name must be the same as the one in the file where the function is defined

--- a/amxmodx/scripting/include/orpheu.inc
+++ b/amxmodx/scripting/include/orpheu.inc
@@ -6,7 +6,6 @@
 
 #include <orpheu_const>
 
-
 /**
  * Retrieves a function based on a function name
  * The name must be the same as the one in the file where the function is defined

--- a/amxmodx/scripting/include/orpheu_advanced.inc
+++ b/amxmodx/scripting/include/orpheu_advanced.inc
@@ -13,7 +13,7 @@
  * @param bytes				An array to hold the bytes
  * @param count				The number of bytes to get
  */
-native OrpheuGetBytesAtAddress(address,bytes[],count)
+native OrpheuGetBytesAtAddress(address,bytes[],count);
 
 /**
  *  Gets the address in memory of a function given a handler to it
@@ -22,7 +22,7 @@ native OrpheuGetBytesAtAddress(address,bytes[],count)
  *
  * @return 					The address o the function
  */
-native OrpheuGetFunctionAddress(OrpheuFunction:function)
+native OrpheuGetFunctionAddress(OrpheuFunction:function);
 
 /**
  *  Gets a handle to a struct given an address in memory
@@ -32,7 +32,7 @@ native OrpheuGetFunctionAddress(OrpheuFunction:function)
  *
  * @return 					A handler to the struct
  */
-native OrpheuStruct:OrpheuGetStructFromAddress(OrpheuStructType:structType,address)
+native OrpheuStruct:OrpheuGetStructFromAddress(OrpheuStructType:structType,address);
 
 /**
  *  Gets the handler to a function given its address and the name that you give it in the file where you define the function
@@ -43,7 +43,7 @@ native OrpheuStruct:OrpheuGetStructFromAddress(OrpheuStructType:structType,addre
  *
  * @return 					A handler to the function
  */
-native OrpheuFunction:OrpheuCreateFunction(address,const libFunctionName[],const classname[]="")
+native OrpheuFunction:OrpheuCreateFunction(address,const libFunctionName[],const classname[]="");
 
 /**
  *  Gets the offset of the adress where the function is located to the base address of its library
@@ -52,7 +52,7 @@ native OrpheuFunction:OrpheuCreateFunction(address,const libFunctionName[],const
  *
  * @return 					The offset
  */
-native OrpheuGetFunctionOffset(OrpheuFunction:function)
+native OrpheuGetFunctionOffset(OrpheuFunction:function);
 
 /**
  *  Gets the adress of a library
@@ -61,7 +61,7 @@ native OrpheuGetFunctionOffset(OrpheuFunction:function)
  *
  * @return 					The address
  */
-native OrpheuGetLibraryAddress(const libraryName[])
+native OrpheuGetLibraryAddress(const libraryName[]);
 
 /**
  *  This native should retrieve the address of functions called from an address
@@ -74,4 +74,4 @@ native OrpheuGetLibraryAddress(const libraryName[])
  *
  * @return 					The address of the function called
  */
-native OrpheuGetNextCallAtAddress(address,number)
+native OrpheuGetNextCallAtAddress(address,number);

--- a/amxmodx/scripting/include/orpheu_const.inc
+++ b/amxmodx/scripting/include/orpheu_const.inc
@@ -13,7 +13,7 @@
  #pragma library orpheu
 #endif
 
-const OrpheuFunction:OrpheuInvalidFunction = OrpheuFunction:0
+const OrpheuFunction:OrpheuInvalidFunction = OrpheuFunction:0;
 
 enum OrpheuHookReturn
 {

--- a/amxmodx/scripting/include/orpheu_memory.inc
+++ b/amxmodx/scripting/include/orpheu_memory.inc
@@ -31,7 +31,7 @@
  * 
  * 		OrpheuMemoryReplace("name",0,"weapon_smokegrenade","weapon_flashbang") (where name should be related to a block of data that qualifies the memory as holding a string)
  */
-native OrpheuMemoryReplace(const memoryDataName[],count,any:...)
+native OrpheuMemoryReplace(const memoryDataName[],count,any:...);
 
 /**
  * Replaces data in memory.It works like OrpheuMemoryReplace but starts at a given address	
@@ -43,7 +43,7 @@ native OrpheuMemoryReplace(const memoryDataName[],count,any:...)
  * 
  * @return 					The number of replacements made
  */
-native OrpheuMemoryReplaceAtAddress(address,const memoryDataNameName[],count,any:...)
+native OrpheuMemoryReplaceAtAddress(address,const memoryDataNameName[],count,any:...);
 
 
 /**
@@ -56,7 +56,7 @@ native OrpheuMemoryReplaceAtAddress(address,const memoryDataNameName[],count,any
  * 
  * @return 					If the type of the memory location is not passed by ref, its value
  */
-native OrpheuMemoryGet(const memoryDataName[],any:...)
+native OrpheuMemoryGet(const memoryDataName[],any:...);
 
 /**
  * Retrieves data in memory. It works like OrpheuMemoryGet but starts at a given address
@@ -68,7 +68,7 @@ native OrpheuMemoryGet(const memoryDataName[],any:...)
  *
  * @return 					If the type of the memory location is not passed by ref, its value
  */
-native OrpheuMemoryGetAtAddress(address,const memoryDataName[],any:...)
+native OrpheuMemoryGetAtAddress(address,const memoryDataName[],any:...);
 
 /**
  * Alters data in memory.  The block of data that qualifies memory must also identify it by having identifier blocks.
@@ -81,7 +81,7 @@ native OrpheuMemoryGetAtAddress(address,const memoryDataName[],any:...)
  *
  * @return 					Number of occurences replaced
  */
-native OrpheuMemorySet(const memoryDataName[],count,any:...)
+native OrpheuMemorySet(const memoryDataName[],count,any:...);
 
 /**
  * Alters data in memory.  It works like OrpheuMemorySet but starts at a given address	
@@ -94,5 +94,5 @@ native OrpheuMemorySet(const memoryDataName[],count,any:...)
  *
  * @return 					Number of occurences replaced
  */
-native OrpheuMemorySetAtAddress(address,const memoryDataName[],count,any:...)
+native OrpheuMemorySetAtAddress(address,const memoryDataName[],count,any:...);
 

--- a/amxmodx/scripting/include/orpheu_stocks.inc
+++ b/amxmodx/scripting/include/orpheu_stocks.inc
@@ -24,14 +24,14 @@
  */
 stock OrpheuFunction:OrpheuGetEngineFunction(const memberName[],const libFunctionName[])
 {
-	static OrpheuStruct:engineFunctions
+	static OrpheuStruct:engineFunctions;
 	
 	if(!engineFunctions)
 	{
-		engineFunctions = OrpheuGetEngineFunctionsStruct()
+		engineFunctions = OrpheuGetEngineFunctionsStruct();
 	}
 	
-	return OrpheuCreateFunction( OrpheuGetStructMember(engineFunctions,memberName),libFunctionName )
+	return OrpheuCreateFunction( OrpheuGetStructMember(engineFunctions,memberName),libFunctionName );
 }
 
 /**
@@ -49,27 +49,27 @@ stock OrpheuFunction:OrpheuGetEngineFunction(const memberName[],const libFunctio
  */
 stock OrpheuFunction:OrpheuGetDLLFunction(const memberName[],const libFunctionName[])
 {
-	static OrpheuStruct:OrpheuDLLFunctions
+	static OrpheuStruct:OrpheuDLLFunctions;
 	
 	if(!OrpheuDLLFunctions)
 	{
-		OrpheuDLLFunctions = OrpheuGetDLLFunctionsStruct()
+		OrpheuDLLFunctions = OrpheuGetDLLFunctionsStruct();
 	}
 	
-	return OrpheuCreateFunction( OrpheuGetStructMember(OrpheuDLLFunctions,memberName),libFunctionName )
+	return OrpheuCreateFunction( OrpheuGetStructMember(OrpheuDLLFunctions,memberName),libFunctionName );
 }
 
 stock OrpheuHook:OrpheuRegisterHookFromClass(const entityClassName[],const libFunctionName[],const libClassName[],const hookFunctionName[],OrpheuHookPhase:phase = OrpheuHookPre)
 {
-	return OrpheuRegisterHook(OrpheuGetFunctionFromClass(entityClassName,libFunctionName,libClassName),hookFunctionName,phase)
+	return OrpheuRegisterHook(OrpheuGetFunctionFromClass(entityClassName,libFunctionName,libClassName),hookFunctionName,phase);
 }
 
 stock OrpheuHook:OrpheuRegisterHookFromEntity(id,const libFunctionName[],const libClassName[],const hookFunctionName[],OrpheuHookPhase:phase = OrpheuHookPre)
 {
-	return OrpheuRegisterHook(OrpheuGetFunctionFromEntity(id,libFunctionName,libClassName),hookFunctionName,phase)
+	return OrpheuRegisterHook(OrpheuGetFunctionFromEntity(id,libFunctionName,libClassName),hookFunctionName,phase);
 }
 
 stock OrpheuHook:OrpheuRegisterHookFromObject(object,const libFunctionName[],const libClassName[],const hookFunctionName[],OrpheuHookPhase:phase = OrpheuHookPre)
 {
-	return OrpheuRegisterHook(OrpheuGetFunctionFromObject(object,libFunctionName,libClassName),hookFunctionName,phase)
+	return OrpheuRegisterHook(OrpheuGetFunctionFromObject(object,libFunctionName,libClassName),hookFunctionName,phase);
 }


### PR DESCRIPTION
It's currently not possible to compile a `#pragma semicolon true` plugin due to orpheu include libraries.
I'm not sure if that happens in other builds than 1.9, but, should be fine to implement tho.