### PR TITLE
Fix bad parsing on CFuncRotating file

### DIFF
--- a/amxmodx/configs/orpheu/types/CBaseEntity/aliases/CFuncRotating
+++ b/amxmodx/configs/orpheu/types/CBaseEntity/aliases/CFuncRotating
@@ -1,6 +1,3 @@
 [
 	"CFuncRotating *"
 ]
-[
-	"CFuncRotating *"
-]


### PR DESCRIPTION
Orpheu logs a bad parsing from CBaseEntity/CFuncRotating on orpheu config output:

```
File "CFuncRotating" incorrectly formatted
			Adding alias"CBaseEntity *"
```